### PR TITLE
Add POST method for Denon Remote App

### DIFF
--- a/ycast/radiobrowser.py
+++ b/ycast/radiobrowser.py
@@ -22,7 +22,7 @@ def get_json_attr(json, attr):
 
 class Station:
     def __init__(self, station_json):
-        self.id = generic.generate_stationid_with_prefix(get_json_attr(station_json, 'id'), ID_PREFIX)
+        self.id = generic.generate_stationid_with_prefix(get_json_attr(station_json, 'stationuuid'), ID_PREFIX)
         self.name = get_json_attr(station_json, 'name')
         self.url = get_json_attr(station_json, 'url')
         self.icon = get_json_attr(station_json, 'favicon')
@@ -49,7 +49,7 @@ def request(url):
     logging.debug("Radiobrowser API request: %s", url)
     headers = {'content-type': 'application/json', 'User-Agent': generic.USER_AGENT + '/' + __version__}
     try:
-        response = requests.get('http://www.radio-browser.info/webservice/json/' + url, headers=headers)
+        response = requests.get('https://de1.api.radio-browser.info/json/' + url, headers=headers)
     except requests.exceptions.ConnectionError as err:
         logging.error("Connection to Radiobrowser API failed (%s)", err)
         return {}
@@ -71,7 +71,7 @@ def search(name, limit=DEFAULT_STATION_LIMIT):
     stations = []
     stations_json = request('stations/search?order=name&reverse=false&limit=' + str(limit) + '&name=' + str(name))
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations
 
@@ -120,27 +120,27 @@ def get_genre_directories():
 
 def get_stations_by_country(country):
     stations = []
-    stations_json = request('stations/search?order=name&reverse=false&countryExact=true&country=' + str(country))
+    stations_json = request('stations/bycountryexact/' + str(country) +'?order=name&reverse=false')
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations
 
 
 def get_stations_by_language(language):
     stations = []
-    stations_json = request('stations/search?order=name&reverse=false&languageExact=true&language=' + str(language))
+    stations_json = request('stations/bylanguageexact/' + str(language) + '?order=name&reverse=false')
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations
 
 
 def get_stations_by_genre(genre):
     stations = []
-    stations_json = request('stations/search?order=name&reverse=false&tagExact=true&tag=' + str(genre))
+    stations_json = request('stations/bytagexact/' + str(genre) + '?order=name&reverse=false')
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations
 
@@ -149,6 +149,6 @@ def get_stations_by_votes(limit=DEFAULT_STATION_LIMIT):
     stations = []
     stations_json = request('stations?order=votes&reverse=true&limit=' + str(limit))
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations

--- a/ycast/server.py
+++ b/ycast/server.py
@@ -113,7 +113,7 @@ def vtuner_redirect(url):
     return redirect(url, code=302)
 
 
-@app.route('/setupapp/<path:path>')
+@app.route('/setupapp/<path:path>', methods=['GET', 'POST'])
 def upstream(path):
     if request.args.get('token') == '0':
         return vtuner.get_init_token()
@@ -127,8 +127,8 @@ def upstream(path):
     abort(404)
 
 
-@app.route('/', defaults={'path': ''})
-@app.route('/' + PATH_ROOT + '/', defaults={'path': ''})
+@app.route('/', defaults={'path': ''}, methods=['GET', 'POST'])
+@app.route('/' + PATH_ROOT + '/', defaults={'path': ''}, methods=['GET', 'POST'])
 def landing(path=''):
     page = vtuner.Page()
     page.add(vtuner.Directory('Radiobrowser', url_for('radiobrowser_landing', _external=True), 4))
@@ -141,19 +141,19 @@ def landing(path=''):
     return page.to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_MY_STATIONS + '/')
+@app.route('/' + PATH_ROOT + '/' + PATH_MY_STATIONS + '/', methods=['GET', 'POST'])
 def my_stations_landing():
     directories = my_stations.get_category_directories()
     return get_directories_page('my_stations_category', directories, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_MY_STATIONS + '/<directory>')
+@app.route('/' + PATH_ROOT + '/' + PATH_MY_STATIONS + '/<directory>', methods=['GET', 'POST'])
 def my_stations_category(directory):
     stations = my_stations.get_stations_by_category(directory)
     return get_stations_page(stations, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/')
+@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/', methods=['GET', 'POST'])
 def radiobrowser_landing():
     page = vtuner.Page()
     page.add(vtuner.Directory('Genres', url_for('radiobrowser_genres', _external=True),
@@ -168,49 +168,49 @@ def radiobrowser_landing():
     return page.to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_COUNTRY + '/')
+@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_COUNTRY + '/', methods=['GET', 'POST'])
 def radiobrowser_countries():
     directories = radiobrowser.get_country_directories()
     return get_directories_page('radiobrowser_country_stations', directories, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_COUNTRY + '/<directory>')
+@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_COUNTRY + '/<directory>', methods=['GET', 'POST'])
 def radiobrowser_country_stations(directory):
     stations = radiobrowser.get_stations_by_country(directory)
     return get_stations_page(stations, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_LANGUAGE + '/')
+@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_LANGUAGE + '/', methods=['GET', 'POST'])
 def radiobrowser_languages():
     directories = radiobrowser.get_language_directories()
     return get_directories_page('radiobrowser_language_stations', directories, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_LANGUAGE + '/<directory>')
+@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_LANGUAGE + '/<directory>', methods=['GET', 'POST'])
 def radiobrowser_language_stations(directory):
     stations = radiobrowser.get_stations_by_language(directory)
     return get_stations_page(stations, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_GENRE + '/')
+@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_GENRE + '/', methods=['GET', 'POST'])
 def radiobrowser_genres():
     directories = radiobrowser.get_genre_directories()
     return get_directories_page('radiobrowser_genre_stations', directories, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_GENRE + '/<directory>')
+@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_GENRE + '/<directory>', methods=['GET', 'POST'])
 def radiobrowser_genre_stations(directory):
     stations = radiobrowser.get_stations_by_genre(directory)
     return get_stations_page(stations, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_POPULAR + '/')
+@app.route('/' + PATH_ROOT + '/' + PATH_RADIOBROWSER + '/' + PATH_RADIOBROWSER_POPULAR + '/', methods=['GET', 'POST'])
 def radiobrowser_popular():
     stations = radiobrowser.get_stations_by_votes()
     return get_stations_page(stations, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_SEARCH + '/')
+@app.route('/' + PATH_ROOT + '/' + PATH_SEARCH + '/', methods=['GET', 'POST'])
 def station_search():
     query = request.args.get('search')
     if not query or len(query) < 3:
@@ -224,7 +224,7 @@ def station_search():
         return get_stations_page(stations, request).to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_PLAY)
+@app.route('/' + PATH_ROOT + '/' + PATH_PLAY, methods=['GET', 'POST'])
 def get_stream_url():
     stationid = request.args.get('id')
     if not stationid:
@@ -238,7 +238,7 @@ def get_stream_url():
     return vtuner_redirect(station.url)
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_STATION)
+@app.route('/' + PATH_ROOT + '/' + PATH_STATION, methods=['GET', 'POST'])
 def get_station_info():
     stationid = request.args.get('id')
     if not stationid:
@@ -261,7 +261,7 @@ def get_station_info():
     return page.to_string()
 
 
-@app.route('/' + PATH_ROOT + '/' + PATH_ICON)
+@app.route('/' + PATH_ROOT + '/' + PATH_ICON, methods=['GET', 'POST'])
 def get_station_icon():
     stationid = request.args.get('id')
     if not stationid:

--- a/ycast/vtuner.py
+++ b/ycast/vtuner.py
@@ -137,7 +137,7 @@ class Station:
         ET.SubElement(item, 'Logo').text = self.icon
         ET.SubElement(item, 'StationFormat').text = self.genre
         ET.SubElement(item, 'StationLocation').text = self.location
-        ET.SubElement(item, 'StationBandWidth').text = self.bitrate
+#        ET.SubElement(item, 'StationBandWidth').text = self.bitrate
         ET.SubElement(item, 'StationMime').text = self.mime
         ET.SubElement(item, 'Relia').text = '3'
         ET.SubElement(item, 'Bookmark').text = self.bookmark


### PR DESCRIPTION
The Denon Remote App (https://play.google.com/store/apps/details?id=com.dmholdings.denonremoteapp) is a bit weird, as it queries vTuner directly, but using POST. The original implementation will lead to HTTP 405. This pull requests simply allows POST next to GET and the Remote App works like charm.