### PR TITLE
Fix for issue #54 to use new radiobrowser API.

### DIFF
--- a/ycast/radiobrowser.py
+++ b/ycast/radiobrowser.py
@@ -22,7 +22,7 @@ def get_json_attr(json, attr):
 
 class Station:
     def __init__(self, station_json):
-        self.id = generic.generate_stationid_with_prefix(get_json_attr(station_json, 'id'), ID_PREFIX)
+        self.id = generic.generate_stationid_with_prefix(get_json_attr(station_json, 'stationuuid'), ID_PREFIX)
         self.name = get_json_attr(station_json, 'name')
         self.url = get_json_attr(station_json, 'url')
         self.icon = get_json_attr(station_json, 'favicon')
@@ -49,7 +49,7 @@ def request(url):
     logging.debug("Radiobrowser API request: %s", url)
     headers = {'content-type': 'application/json', 'User-Agent': generic.USER_AGENT + '/' + __version__}
     try:
-        response = requests.get('http://www.radio-browser.info/webservice/json/' + url, headers=headers)
+        response = requests.get('https://de1.api.radio-browser.info/json/' + url, headers=headers)
     except requests.exceptions.ConnectionError as err:
         logging.error("Connection to Radiobrowser API failed (%s)", err)
         return {}
@@ -71,7 +71,7 @@ def search(name, limit=DEFAULT_STATION_LIMIT):
     stations = []
     stations_json = request('stations/search?order=name&reverse=false&limit=' + str(limit) + '&name=' + str(name))
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations
 
@@ -120,27 +120,27 @@ def get_genre_directories():
 
 def get_stations_by_country(country):
     stations = []
-    stations_json = request('stations/search?order=name&reverse=false&countryExact=true&country=' + str(country))
+    stations_json = request('stations/bycountryexact/' + str(country) +'?order=name&reverse=false')
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations
 
 
 def get_stations_by_language(language):
     stations = []
-    stations_json = request('stations/search?order=name&reverse=false&languageExact=true&language=' + str(language))
+    stations_json = request('stations/bylanguageexact/' + str(language) + '?order=name&reverse=false')
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations
 
 
 def get_stations_by_genre(genre):
     stations = []
-    stations_json = request('stations/search?order=name&reverse=false&tagExact=true&tag=' + str(genre))
+    stations_json = request('stations/bytagexact/' + str(genre) + '?order=name&reverse=false')
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations
 
@@ -149,6 +149,6 @@ def get_stations_by_votes(limit=DEFAULT_STATION_LIMIT):
     stations = []
     stations_json = request('stations?order=votes&reverse=true&limit=' + str(limit))
     for station_json in stations_json:
-        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == '1':
+        if SHOW_BROKEN_STATIONS or get_json_attr(station_json, 'lastcheckok') == 1:
             stations.append(Station(station_json))
     return stations

--- a/ycast/vtuner.py
+++ b/ycast/vtuner.py
@@ -137,7 +137,7 @@ class Station:
         ET.SubElement(item, 'Logo').text = self.icon
         ET.SubElement(item, 'StationFormat').text = self.genre
         ET.SubElement(item, 'StationLocation').text = self.location
-        ET.SubElement(item, 'StationBandWidth').text = self.bitrate
+#        ET.SubElement(item, 'StationBandWidth').text = self.bitrate
         ET.SubElement(item, 'StationMime').text = self.mime
         ET.SubElement(item, 'Relia').text = '3'
         ET.SubElement(item, 'Bookmark').text = self.bookmark


### PR DESCRIPTION
Fix for issue #54 to use new radiobrowser API.
API-server is hard-coded not determined at run-time as recommended in the radiobrowser API documentation.