### PR TITLE
Update server.py - NOXON iRadio and NOXON 2 working

### DIFF
--- a/ycast/my_stations.py
+++ b/ycast/my_stations.py
@@ -1,7 +1,7 @@
 import logging
 import hashlib
 
-import yaml
+import oyaml as yaml
 
 import ycast.vtuner as vtuner
 import ycast.generic as generic

--- a/ycast/server.py
+++ b/ycast/server.py
@@ -133,6 +133,8 @@ def upstream(path):
         return my_stations_landing()
     if 'loginXML.asp' in path:
         return landing()
+    if 'LoginXML.asp' in path:
+        return landing()
     logging.error("Unhandled upstream query (/setupapp/%s)", path)
     abort(404)
 


### PR DESCRIPTION
Added response to "Login.XML" request. Originally only "login.XML" could be resolved. 
While testing with a proxy, I recognized, that vintage NOXON radios submit the request with an upper case "L".
Now it is working with NOXON 2 and NOXON iRadio.

2nd change: Replaced line 4 in stations.py with
`import oyaml as yaml`
Note: Install oyaml (https://github.com/wimglenn/oyaml) before using this version. 
Result: Stations from stations.yml now appear in the original order as written in the file.