### PR TITLE
Allow favicons in favourites

### DIFF
--- a/ycast/my_stations.py
+++ b/ycast/my_stations.py
@@ -12,12 +12,12 @@ config_file = 'stations.yml'
 
 
 class Station:
-    def __init__(self, uid, name, url, category):
+    def __init__(self, uid, name, url, category, icon):
         self.id = generic.generate_stationid_with_prefix(uid, ID_PREFIX)
         self.name = name
         self.url = url
         self.tag = category
-        self.icon = None
+        self.icon = icon
 
     def to_vtuner(self):
         return vtuner.Station(self.id, self.name, self.tag, self.url, self.icon, self.tag, None, None, None, None)
@@ -70,9 +70,14 @@ def get_stations_by_category(category):
     stations = []
     if my_stations_yaml and category in my_stations_yaml:
         for station_name in my_stations_yaml[category]:
-            station_url = my_stations_yaml[category][station_name]
+            station_urls = my_stations_yaml[category][station_name]
+            url_list = station_urls.split('|')
+            station_url = url_list[0]
+            station_icon = None
+            if len(url_list) > 1:
+                station_icon = url_list[1]
             station_id = str(get_checksum(station_name + station_url)).upper()
-            stations.append(Station(station_id, station_name, station_url, category))
+            stations.append(Station(station_id, station_name, station_url, category, station_icon))
     return stations
 
 


### PR DESCRIPTION
With the delimiter '|' you can optionally add a favicon URL to the station entry in the station.yml favorites list.
e.g.:
```
Aktuell:
  Deutschlandfunk: http://st01.dlf.de/dlf/01/128/mp3/stream.mp3
  Deutschlandfunk Nova: http://st04.dlf.de/dlf/04/64/mp3/stream.mp3|https://www.deutschlandfunknova.de/apple-touch-icon-precomposed.png
```


