### PR TITLE
Add requests caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .idea
 *.iml
 *.pyc
+*.sqlite

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
         'onkyo',
         'denon'
     ],
-    install_requires=['requests', 'flask', 'PyYAML', 'Pillow'],
+    install_requires=['requests', 'flask', 'PyYAML', 'Pillow', 'requests-cache', 'APScheduler'],
     packages=find_packages(exclude=['contrib', 'docs', 'tests'])
 )

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='ycast-cache',
+    name='ycast',
     version=ycast.__version__,
     author='milaq',
     author_email='micha.laqua@gmail.com',
     description='Self hosted vTuner internet radio service emulation',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/milaq/YCast-Cache',
+    url='https://github.com/milaq/YCast',
     license='GPLv3',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='ycast',
+    name='ycast-cache',
     version=ycast.__version__,
     author='milaq',
     author_email='micha.laqua@gmail.com',
     description='Self hosted vTuner internet radio service emulation',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/milaq/YCast',
+    url='https://github.com/milaq/YCast-Cache',
     license='GPLv3',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/ycast/my_stations.py
+++ b/ycast/my_stations.py
@@ -12,12 +12,12 @@ config_file = 'stations.yml'
 
 
 class Station:
-    def __init__(self, uid, name, url, category):
+    def __init__(self, uid, name, url, category, icon):
         self.id = generic.generate_stationid_with_prefix(uid, ID_PREFIX)
         self.name = name
         self.url = url
         self.tag = category
-        self.icon = None
+        self.icon = icon
 
     def to_vtuner(self):
         return vtuner.Station(self.id, self.name, self.tag, self.url, self.icon, self.tag, None, None, None, None)
@@ -70,9 +70,10 @@ def get_stations_by_category(category):
     stations = []
     if my_stations_yaml and category in my_stations_yaml:
         for station_name in my_stations_yaml[category]:
-            station_url = my_stations_yaml[category][station_name]
+            station_url = my_stations_yaml[category][station_name]['url']
+            station_icon = my_stations_yaml[category][station_name]['icon']
             station_id = str(get_checksum(station_name + station_url)).upper()
-            stations.append(Station(station_id, station_name, station_url, category))
+            stations.append(Station(station_id, station_name, station_url, category, station_icon))
     return stations
 
 

--- a/ycast/radiobrowser.py
+++ b/ycast/radiobrowser.py
@@ -13,7 +13,7 @@ MINIMUM_COUNT_LANGUAGE = 5
 DEFAULT_STATION_LIMIT = 200
 SHOW_BROKEN_STATIONS = False
 ID_PREFIX = "RB"
-session = requests_cache.CachedSession('ycast_cache')
+session = requests_cache.CachedSession('ycast_cache', backend='memory')
 
 
 def get_json_attr(json, attr):

--- a/ycast/radiobrowser.py
+++ b/ycast/radiobrowser.py
@@ -4,14 +4,16 @@ import logging
 from ycast import __version__
 import ycast.vtuner as vtuner
 import ycast.generic as generic
+import requests_cache
 
 API_ENDPOINT = "http://all.api.radio-browser.info"
-MINIMUM_COUNT_GENRE = 5
+MINIMUM_COUNT_GENRE = 15
 MINIMUM_COUNT_COUNTRY = 5
 MINIMUM_COUNT_LANGUAGE = 5
 DEFAULT_STATION_LIMIT = 200
 SHOW_BROKEN_STATIONS = False
 ID_PREFIX = "RB"
+session = requests_cache.CachedSession('ycast_cache')
 
 
 def get_json_attr(json, attr):
@@ -50,7 +52,7 @@ def request(url):
     logging.debug("Radiobrowser API request: %s", url)
     headers = {'content-type': 'application/json', 'User-Agent': generic.USER_AGENT + '/' + __version__}
     try:
-        response = requests.get(API_ENDPOINT + '/json/' + url, headers=headers)
+        response = session.get(API_ENDPOINT + '/json/' + url, headers=headers)
     except requests.exceptions.ConnectionError as err:
         logging.error("Connection to Radiobrowser API failed (%s)", err)
         return {}

--- a/ycast/server.py
+++ b/ycast/server.py
@@ -1,14 +1,15 @@
 import logging
 import re
 
+import requests_cache
 from flask import Flask, request, url_for, redirect, abort, make_response
+from apscheduler.schedulers.background import BackgroundScheduler
 
 import ycast.vtuner as vtuner
 import ycast.radiobrowser as radiobrowser
 import ycast.my_stations as my_stations
 import ycast.generic as generic
 import ycast.station_icons as station_icons
-
 
 PATH_ROOT = 'ycast'
 PATH_PLAY = 'play'
@@ -27,8 +28,27 @@ my_stations_enabled = False
 app = Flask(__name__)
 
 
+def revalidate_cache():
+    logging.info("Starting cache revalidation")
+    session = requests_cache.CachedSession('ycast_cache')
+    get_urls = [
+        response.url for response in session.cache.responses.values()
+        if response.request.method == 'GET'
+    ]
+    session.cache.clear()
+    for url in get_urls[:25]:
+        session.get(url)
+    logging.info("Cache revalidated")
+
+
+sched = BackgroundScheduler(daemon=True)
+sched.add_job(revalidate_cache, 'interval', hours=6)
+sched.start()
+
+
 def run(config, address='0.0.0.0', port=8010):
     try:
+        revalidate_cache()
         check_my_stations_feature(config)
         app.run(host=address, port=port)
     except PermissionError:

--- a/ycast/server.py
+++ b/ycast/server.py
@@ -30,7 +30,7 @@ app = Flask(__name__)
 
 def revalidate_cache():
     logging.info("Starting cache revalidation")
-    session = requests_cache.CachedSession('ycast_cache')
+    session = requests_cache.CachedSession('ycast_cache', backend='memory')
     get_urls = [
         response.url for response in session.cache.responses.values()
         if response.request.method == 'GET'


### PR DESCRIPTION
Cache requests using `requests-cache`.  
This speeds up the loading times significally. In my case from 4s to 200ms (!).  

The cache is also asynchronously revalidated every 6 hours so it never gets stale.